### PR TITLE
DiffUtil RecyclerView

### DIFF
--- a/Confroid/app/src/main/java/fr/uge/confroid/web/FileAdapter.kt
+++ b/Confroid/app/src/main/java/fr/uge/confroid/web/FileAdapter.kt
@@ -6,6 +6,7 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import fr.uge.confroid.R
 
@@ -25,6 +26,24 @@ class FileAdapter(val listener: OnFileListener, var requests: List<FileAttribute
 
         fun update(fileAttributes: FileAttributes) {
             textView.text = fileAttributes.name
+        }
+    }
+
+    inner class FileDiffUtil(val old : List<FileAttributes>, val current : List<FileAttributes>) : DiffUtil.Callback() {
+        override fun getOldListSize(): Int {
+            return old.size
+        }
+
+        override fun getNewListSize(): Int {
+            return current.size
+        }
+
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            return old[oldItemPosition] == current[newItemPosition]
+        }
+
+        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            return old[oldItemPosition] == current[newItemPosition]
         }
     }
 
@@ -48,5 +67,14 @@ class FileAdapter(val listener: OnFileListener, var requests: List<FileAttribute
 
     override fun getItemCount(): Int {
         return requests.size
+    }
+
+    fun updateRequests(fileAttributes: List<FileAttributes>) {
+        val old = requests
+        val diff = DiffUtil.calculateDiff(
+            FileDiffUtil(old, fileAttributes)
+        )
+        requests = fileAttributes
+        diff.dispatchUpdatesTo(this)
     }
 }

--- a/Confroid/app/src/main/java/fr/uge/confroid/web/FilesFragment.kt
+++ b/Confroid/app/src/main/java/fr/uge/confroid/web/FilesFragment.kt
@@ -107,8 +107,7 @@ class FilesFragment : Fragment(R.layout.fragment_files), FileAdapter.OnFileListe
 
     private suspend fun updateAdapter(requestBody : String) {
         val files = parse(requestBody)
-        fileAdapter.requests = files
-        fileAdapter.notifyDataSetChanged()
+        fileAdapter.updateRequests(files)
     }
 
     private fun getFiles(token: String) {


### PR DESCRIPTION
Uses [DiffUtil](https://developer.android.com/reference/androidx/recyclerview/widget/DiffUtil) that allows us to update in a async way the list of the recyclerView.
Added `inner class FileDiffUtil(val old : List<FileAttributes>, val current : List<FileAttributes>) : DiffUtil.Callback()` in *FileAdapter* then the method `fun updateRequests(fileAttributes: List<FileAttributes>)` to update the list.